### PR TITLE
Fix for compatibility with nodejs 6.9.1 and 7.2.0

### DIFF
--- a/mqtt2opcua.js
+++ b/mqtt2opcua.js
@@ -32,7 +32,7 @@ function Matcher(handlers) {
 
 Matcher.prototype = Object.create(Events.prototype);
 Matcher.prototype.match = function (topic) {
-    if (this._events.hasOwnProperty(topic)){
+    if (Object.prototype.hasOwnProperty.call(this._events, topic)){
         return this._events[topic];
     }
     var matches = this.matcher.match(topic);
@@ -41,7 +41,7 @@ Matcher.prototype.match = function (topic) {
 
 Matcher.prototype.init = function () {
     for (var e in this._events) {
-        if (this._events.hasOwnProperty(e)) {
+        if (Object.prototype.hasOwnProperty.call(this._events, e)) {
             this.matcher.add(e, this._events[e]);
         }
     }


### PR DESCRIPTION
Fixed problems with function .hasOwnProperty.
"TypeError: this._events.hasOwnProperty is not a function"
Not tested with older nodejs versions < 6.9.1.

Ubuntu 16.10 64 bit
Kernel 4.8.0-28-generic